### PR TITLE
rename command line to h1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     python_requires='>= 3',
     entry_points="""
     [console_scripts]
-    h1st=h1st.cli:main
+    h1=h1st.cli:main
     """,
     extras_require={}
 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -25,12 +25,12 @@ class CliTestCase(TestCase):
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             subprocess.check_call(
-                ["h1st", "new-project", "AutoCyber"],
+                ["h1", "new-project", "AutoCyber"],
                 cwd=tmpdir
             )
 
             subprocess.check_call(
-                ["h1st", "new-model", "Model2"],
+                ["h1", "new-model", "Model2"],
                 cwd=tmpdir + '/AutoCyber'
             )
 


### PR DESCRIPTION
Rename command line from `h1st` to `h1` according to #11