### PR TITLE
Improve documentation & error handling for Forecasting example

### DIFF
--- a/examples/Forecasting/models/forecast.py
+++ b/examples/Forecasting/models/forecast.py
@@ -3,6 +3,7 @@ import pandas as pd
 import os
 import sklearn
 import sklearn.metrics
+import subprocess
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.compose import make_column_transformer
@@ -22,12 +23,11 @@ class ForecastModel(h1.Model):
         self.data_dir = config.FORECAST_DATA_PATH
     
     def load_data(self):
-        # does it "fetch" the data or also perform join etc.?
         # needs to have kaggle tools, and user credentials, and agreed to competition rules etc.
-        os.system("mkdir {data}".format(data=self.data_dir))
+        subprocess.run("mkdir {data}".format(data=self.data_dir), shell=True, check=True)
         if not os.path.isfile(os.path.join(self.data_dir, "train.csv")):
-            os.system("kaggle competitions download -c rossmann-store-sales -p {data}/".format(data=self.data_dir))
-            os.system("cd {data}; unzip rossmann-store-sales.zip".format(data=self.data_dir))
+            subprocess.run("kaggle competitions download -c rossmann-store-sales -p {data}/".format(data=self.data_dir), shell=True, check=True)
+            subprocess.run("cd {data}; unzip rossmann-store-sales.zip".format(data=self.data_dir), shell=True, check=True)
 
         df = pd.read_csv(os.path.join(self.data_dir, "train.csv"), low_memory=False)
 

--- a/examples/Forecasting/notebooks/forecast.ipynb
+++ b/examples/Forecasting/notebooks/forecast.ipynb
@@ -27,6 +27,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will download data from Kaggle, you'll need to have the `kaggle` commandline tools & user credentials setup at https://www.kaggle.com/docs/api\n",
+    "# Also you'll need to agree to the Rossman Store Sales Forecast competition rules at https://www.kaggle.com/c/rossmann-store-sales\n",
+    "data = m.load_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {
     "tags": []
@@ -39,7 +50,7 @@
     }
    ],
    "source": [
-    "prepared_data = m.prep_data(m.load_data())"
+    "prepared_data = m.prep_data(data)"
    ]
   },
   {


### PR DESCRIPTION
* Add notes & requirements on load_data re kaggle tool & agreement both in notebooks in model file
* Also use subprocess.run() instead of os.system which fails silently, now you'll get error that relates to `kaggle competitions download -c rossmann-store-sales` instead of FileNotFoundError.

Partially fixes #8 