### PR TITLE
fix issue: node output is none

### DIFF
--- a/h1st/core/node.py
+++ b/h1st/core/node.py
@@ -158,6 +158,8 @@ class Node:
         # state = state or {}
         if node_output:
             state.update(node_output)
+        else:
+            node_output = {}
 
         # recursively executing downstream nodes
         for edge in self.edges:


### PR DESCRIPTION
For some reasons, DS want to add dummy models to graph for testing without  returning any data. Even output of the model is required a dictionary but None could be accepted.