### PR TITLE
Put base funtionality into MLModel, RuleBasedModel

### DIFF
--- a/examples/HelloWorld/ml_model.py
+++ b/examples/HelloWorld/ml_model.py
@@ -7,7 +7,7 @@ from sklearn import svm, datasets, metrics
 import h1st as h1
 
 
-class MLModel(h1.Model):
+class MLModel(h1.MLModel):
     def __init__(self):
         self._native_model = svm.SVC(gamma=0.001, C=100.)
 
@@ -40,8 +40,8 @@ class MLModel(h1.Model):
         metric = metrics.accuracy_score(data["test_y"], pred_y)
         return metric
 
-    """
-    We expect an array of input data rows in the "x" field of the input_data dict
-    """
-    def predict(self, input_data):
+    def predict(self, input_data: dict) -> dict:
+        """
+        We expect an array of input data rows in the "x" field of the input_data dict
+        """
         return self._native_model.predict(input_data["x"])

--- a/h1st/core/ml_model.py
+++ b/h1st/core/ml_model.py
@@ -1,0 +1,12 @@
+from typing import Any
+import h1st as h1
+
+class MLModel(h1.Model):
+
+    @property
+    def base_model(self) -> Any:
+        return getattr(self, "__base_model", None)
+
+    @base_model.setter
+    def base_model(self, value):
+        setattr(self, "__base_model", value)

--- a/h1st/core/rule_based_model.py
+++ b/h1st/core/rule_based_model.py
@@ -1,0 +1,6 @@
+import h1st as h1
+
+class RuleBasedModel(h1.Model):
+
+    def predict(self, input_data: dict) -> dict:
+        raise NotImplementedError(input_data)


### PR DESCRIPTION
Support some base functionality in `core.MLModel` so that clients don't have to do custom work, e.g., `self.base_model`.