### PR TITLE
Expose MLModel & RuleBasedModel to root namespace

### DIFF
--- a/h1st/core/__init__.py
+++ b/h1st/core/__init__.py
@@ -1,6 +1,8 @@
 from h1st.core.context import Context, init, setup_logger
 from h1st.core.graph import Graph
 from h1st.core.model import Model
+from h1st.core.ml_model import MLModel
+from h1st.core.rule_based_model import RuleBasedModel
 from h1st.core.node import Action, Decision
 from h1st.core.exception import GraphException
 from h1st.core.node_containable import NodeContainable

--- a/h1st/core/ml_model.py
+++ b/h1st/core/ml_model.py
@@ -1,7 +1,8 @@
 from typing import Any
-import h1st as h1
+from h1st.core.model import Model
 
-class MLModel(h1.Model):
+
+class MLModel(Model):
 
     @property
     def base_model(self) -> Any:

--- a/h1st/core/rule_based_model.py
+++ b/h1st/core/rule_based_model.py
@@ -1,6 +1,5 @@
-import h1st as h1
+from h1st.core.model import Model
 
-class RuleBasedModel(h1.Model):
-
+class RuleBasedModel(Model):
     def predict(self, input_data: dict) -> dict:
-        raise NotImplementedError(input_data)
+        raise NotImplementedError()

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,5 +1,5 @@
 from unittest import TestCase, skip
-from h1st import Model
+from h1st import Model, RuleBasedModel
 from h1st.model_repository import ModelRepository, ModelSerDe
 from h1st.model_repository.storage.local import LocalStorage
 import tempfile
@@ -174,6 +174,7 @@ class ModelSerDeTestCase(TestCase):
 
         self.assert_models(MyModel, 'tensorflow-keras', 'model_Iris', 'dict')
 
+
 class ModelRepositoryTestCase(TestCase):
     def test_serialize_sklearn_model(self):
         class MyModel(Model):
@@ -236,3 +237,13 @@ class ModelStatsSerDeTestCase(TestCase):
 
                 model_serde.deserialize(model_2, path)
                 assert 'CarSpeed' in model_2.stats
+
+
+class RuleModelTestCase(TestCase):
+    def test_ruled_based_model(self):
+        class MyRule(RuleBasedModel):
+            def predict(self, input_data):
+                return {"result": sum(input_data['X'])}
+
+        model = MyRule()
+        self.assertEquals({'result': 42}, model.predict({'X': [1, 1, 10, 10, 20]}))


### PR DESCRIPTION
Expose MLModel and RuleBasedModel to root name space, so we can do `h1.MLModel`. Also add a smoke test for the import

Note: within the framework, we should refer to direct package to avoid circular reference.
