### PR TITLE
Fix links to AutoCyber folder github from the tutorial

### DIFF
--- a/examples/AutoCyber/1. Automotive Cybersecurity - A Cold Start Problem.ipynb
+++ b/examples/AutoCyber/1. Automotive Cybersecurity - A Cold Start Problem.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "\n",
     "```{note}\n",
-    "All the tutorial notebooks and code is available from the H1st Github project at [https://github.com/h1st-ai/h1st/tree/master/examples/AutomotiveCybersecurity](https://github.com/h1st-ai/h1st/tree/master/examples/AutomotiveCybersecurity).\n",
+    "All the tutorial notebooks and code is available from the H1st Github project at [https://github.com/h1st-ai/h1st/tree/master/examples/AutoCyber](https://github.com/h1st-ai/h1st/tree/master/examples/AutoCyber).\n",
     "\n",
     "Simply go ahead and clone it, then follow along.\n",
     "\n",

--- a/examples/AutoCyber/3. Using H1st.AI to Encode Human Insights as a Model and Harmonize Human + ML in a H1st.Graph.ipynb
+++ b/examples/AutoCyber/3. Using H1st.AI to Encode Human Insights as a Model and Harmonize Human + ML in a H1st.Graph.ipynb
@@ -75,7 +75,7 @@
     "Organizing model code this way makes it easy to use. The Model API is uniquely designed so that models can be used interactively in notebooks as well as in more complex project such as this one.\n",
     "\n",
     "```{note}\n",
-    "The H1st package of the full tutorial is available from the H1st Github project at [https://github.com/h1st-ai/h1st/tree/master/examples/AutomotiveCybersecurity](https://github.com/h1st-ai/h1st/tree/master/examples/AutomotiveCybersecurity).\n",
+    "The H1st package of the full tutorial is available from the H1st Github project at [https://github.com/h1st-ai/h1st/tree/master/examples/AutoCyber](https://github.com/h1st-ai/h1st/tree/master/examples/AutoCyber).\n",
     "\n",
     "Simply go ahead and clone it, then follow along.\n",
     "```\n",


### PR DESCRIPTION
Broken after the rename.