### PR TITLE
chore: enable AWS Cloudwatch driver for logging

### DIFF
--- a/examples/AIcargo/docker-compose.yml
+++ b/examples/AIcargo/docker-compose.yml
@@ -58,6 +58,8 @@ services:
             - DJANGO_DEBUG=False
             - SENTRY_URL=${SENTRY_URL}
             - SECRET_KEY=${SECRET_KEY}
+        logging:
+            driver: awslogs
         volumes: 
             - ./model_repo/tensorflow_models/:/app/model_repo/tensorflow_models
             - ./uploaded:/app/uploaded


### PR DESCRIPTION
> The awslogs logging driver sends container logs to Amazon CloudWatch Logs

Reference - https://docs.docker.com/config/containers/logging/awslogs/
