### PR TITLE
chore: enable AWS Cloudwatch driver for logging

### DIFF
--- a/examples/AIcargo/docker-compose.aws.yml
+++ b/examples/AIcargo/docker-compose.aws.yml
@@ -1,0 +1,105 @@
+version: "3"
+
+services:
+    proxy:
+        image: traefik:v2.4.2
+        command:
+            # - "--log.level=DEBUG"
+            - "--api"
+            - "--api.dashboard"
+            # - "--api.insecure" # Don't do that in production
+            - "--providers.docker"
+            - "--entrypoints.web.address=:80"
+            - traefik.http.middlewares.https_redirect.redirectscheme.scheme=https
+            - traefik.http.middlewares.https_redirect.redirectscheme.permanent=true
+            - traefik.http.routers.http_catchall.rule=HostRegexp(`{any:.+}`)
+            - traefik.http.routers.http_catchall.entrypoints=http
+            - traefik.http.routers.http_catchall.middlewares=https_redirect
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        ports:
+            - "80:80"
+            - "9000:8080"
+        logging:
+            driver: awslogs
+            options:
+                awslogs-group: aicargo-logs
+                awslogs-stream: traefik
+    web:
+        build: 
+            context: ./h1st_react
+
+        # command: serve -s build
+        ports:
+            - "5000:5000"
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.web.rule=PathPrefix(`/aicargo`)"
+            - "traefik.http.routers.web.entrypoints=web"
+            - "traefik.http.routers.web.middlewares=web-stripprefix"
+            - "traefik.http.middlewares.web-stripprefix.stripprefix.prefixes=/aicargo"
+            - "traefik.http.middlewares.web-stripprefix.stripprefix.forceslash=true"
+        logging:
+            driver: awslogs
+            options:
+                awslogs-group: aicargo-logs
+                awslogs-stream: ui
+    api:
+        build: .
+        # command: python manage.py runserver 0.0.0.0:8000
+        ports:
+            - "8000:8000"
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.api.rule=PathPrefix(`/aicargo/api`)"
+            - "traefik.http.routers.api.entrypoints=web"
+            - "traefik.http.routers.api.middlewares=api-stripprefix"
+            - "traefik.http.middlewares.api-stripprefix.stripprefix.prefixes=/aicargo"
+            - "traefik.http.middlewares.api-stripprefix.stripprefix.forceslash=true"
+        environment:
+            - TENSORFLOW_SERVER=http://tf_serving:8501/v1/models
+            - TENSORFLOW_GRPC_SERVER=tf_serving:8500
+            - PYTORCH_SERVER=http://pt_serving:8080
+            - MH_DB_NAME=${MH_DB_NAME}
+            - MH_DB_USER=${MH_DB_USER}
+            - MH_DB_PASSWORD=${MH_DB_PASSWORD}
+            - MH_DB_HOST=${MH_DB_HOST}
+            - MH_DB_PORT=${MH_DB_PORT}
+            - DJANGO_DEBUG=False
+            - SENTRY_URL=${SENTRY_URL}
+            - SECRET_KEY=${SECRET_KEY}
+        logging:
+            driver: awslogs
+            options:
+                awslogs-group: aicargo-logs
+                awslogs-stream: api
+        volumes: 
+            - ./model_repo/tensorflow_models/:/app/model_repo/tensorflow_models
+            - ./uploaded:/app/uploaded
+    tf_serving:
+        ports:
+            - "8501:8501"
+            - "8500:8500"
+        volumes:
+            - ./model_repo/tensorflow_models/:/models/
+        image: tensorflow/serving
+        # Temporarily disable prometheus because somehow it blocks port 8501
+        # command: --model_config_file=/models/models.config --monitoring_config_file=/monitoring/prometheus.config
+        command: --model_config_file=/models/models.config
+        logging:
+            driver: awslogs
+            options:
+                awslogs-group: aicargo-logs
+                awslogs-stream: tf-serving
+    pt_serving:
+        ports:
+            - "8080:8080"
+            - "8081:8081"
+        volumes:
+            - ./model_repo/pytorch_models:/home/model-server/model-store
+        image: pytorch/torchserve
+        logging:
+            driver: awslogs
+            options:
+                awslogs-group: aicargo-logs
+                awslogs-stream: pt-serving


### PR DESCRIPTION
1. Create a file `/etc/docker/daemon.json` with the content
```
{
  "log-driver": "awslogs"
}
```
2. Ensure the required AWS group and IAM role are set for the container
3. Execute the command,
```
docker-compose -f docker-compose.aws.yml build
docker-compose -f docker-compose.aws.yml up -d
```

Reference - https://docs.docker.com/config/containers/logging/awslogs/
